### PR TITLE
🚨 Fix GitHub attestation verification

### DIFF
--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -97,4 +97,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          gh attestation verify "oci://ghcr.io/${{ github.repository }}:${REF_NAME}" --repo ${{ github.repository }}
+          gh attestation verify \
+          "oci://ghcr.io/${{ github.repository }}:${REF_NAME}" \
+          --repo ${{ github.repository }} \
+          --signer-workflow ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml

--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -98,6 +98,6 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           gh attestation verify \
-          "oci://ghcr.io/${{ github.repository }}:${REF_NAME}" \
-          --repo ${{ github.repository }} \
-          --signer-workflow ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml
+            "oci://ghcr.io/${{ github.repository }}:${REF_NAME}" \
+            --repo ${{ github.repository }} \
+            --signer-workflow ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml


### PR DESCRIPTION
## Proposed Changes

- Add `--signer-workflow` flag to fix attestation verification

## Notes:

Before it was failing with `Error: verifying with issuer "sigstore.dev"` ([source](https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base/actions/runs/14248258082/job/39934585044?pr=134#step:12:10)), which I can reproduce

```bash
$ gh attestation verify "oci://ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.16.1-rc2" --repo ministryofjustice/analytical-platform-cloud-development-environment-base
Loaded digest sha256:177b0fcb4e4891c39a41820c1c669e03cd37b0924d54dd465641f9173f918577 for oci://ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.16.1-rc2
Loaded 2 attestations from GitHub API

The following policy criteria will be enforced:
- Predicate type must match:................ https://slsa.dev/provenance/v1
- Source Repository Owner URI must match:... https://github.com/ministryofjustice
- Source Repository URI must match:......... https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base
- Subject Alternative Name must match regex: (?i)^https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base/
- OIDC Issuer must match:................... https://token.actions.githubusercontent.com

✗ Sigstore verification failed

Error: verifying with issuer "sigstore.dev"
```

Adding this flag results in

```bash
$ gh attestation verify \                                                                                                                                                                                  
  "oci://ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.16.1-rc2" \
  --repo ministryofjustice/analytical-platform-cloud-development-environment-base \
  --signer-workflow ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml

Loaded digest sha256:177b0fcb4e4891c39a41820c1c669e03cd37b0924d54dd465641f9173f918577 for oci://ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base:1.16.1-rc2
Loaded 2 attestations from GitHub API

The following policy criteria will be enforced:
- Predicate type must match:................ https://slsa.dev/provenance/v1
- Source Repository Owner URI must match:... https://github.com/ministryofjustice
- Source Repository URI must match:......... https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base
- Subject Alternative Name must match regex: ^https://github.com/ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml
- OIDC Issuer must match:................... https://token.actions.githubusercontent.com

✓ Verification succeeded!

The following 1 attestation matched the policy criteria

- Attestation #1
  - Build repo:..... ministryofjustice/analytical-platform-cloud-development-environment-base
  - Build workflow:. .github/workflows/container-release.yml@refs/tags/1.16.1-rc2
  - Signer repo:.... ministryofjustice/analytical-platform-github-actions
  - Signer workflow: .github/workflows/reusable-container-release.yml@a428f866f5c0c12312ece3f21ea99573104078fd
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>