### PR TITLE
🪄 Generate .trivyignore on scan

### DIFF
--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -54,8 +54,10 @@ jobs:
               jq -r '.content' <<< "${downloadTrivyignore}" | base64 --decode > .base-trivyignore
 
               if [[ ! -f .trivyignore ]]; then
+                echo ".trivyignore not found, creating new file"
                 mv .base-trivyignore .trivyignore
               else
+                echo ".trivyignore already exists, merging with existing file"
                 cat .base-trivyignore >> .trivyignore
               fi
 


### PR DESCRIPTION
## Proposed Changes

- Extends `.github/workflows/reusable-container-scan.yml` with logic for downloading and merging a `.trivyignore` from the base image if it comes from Analytical Platform

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>