### PR TITLE
🗺️ Workflows for linting and releasing a Helm chart

### DIFF
--- a/.github/workflows/reusable-chart-lint.yml
+++ b/.github/workflows/reusable-chart-lint.yml
@@ -2,7 +2,7 @@
 on:
   workflow_call:
     inputs:
-      chart_path:
+      chart-path:
         type: string
         required: false
         default: chart
@@ -34,6 +34,6 @@ jobs:
         id: lint_chart
         shell: bash
         env:
-          CHART_PATH: ${{ inputs.chart_path }}
+          CHART_PATH: ${{ inputs.chart-path }}
         run: |
           ct lint --charts "${CHART_PATH}"

--- a/.github/workflows/reusable-chart-lint.yml
+++ b/.github/workflows/reusable-chart-lint.yml
@@ -1,0 +1,39 @@
+---
+on:
+  workflow_call:
+    inputs:
+      chart_path:
+        type: string
+        required: false
+        default: chart
+
+permissions: {}
+
+jobs:
+  chart-lint:
+    name: Chart Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set Up Helm
+        id: setup_helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Set Up Helm Chart Testing
+        id: setup_chart_testing
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+
+      - name: Lint Chart
+        id: lint_chart
+        shell: bash
+        env:
+          CHART_PATH: ${{ inputs.chart_path }}
+        run: |
+          ct lint --charts "${CHART_PATH}"

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -17,7 +17,9 @@ jobs:
     name: Chart Release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: read
+      attestations: write
+      contents: write
       id-token: write
       packages: write
     steps:
@@ -55,3 +57,24 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           helm push ".helm-deploy/${CHART_NAME}-${REF_NAME}.tgz" oci://ghcr.io/ministryofjustice/analytical-platform-charts
+
+      - name: Attest
+        id: attest
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-name: ghcr.io/ministryofjustice/analytical-platform-charts/${{ inputs.chart-name }}
+          subject-digest: ${{ steps.push_chart.outputs.digest }}
+          push-to-registry: true
+
+      - name: GitHub Attestation Verify
+        id: gh_attestation_verify
+        shell: bash
+        env:
+          CHART_NAME: ${{ inputs.chart-name }}
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          gh attestation verify \
+            "oci://ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}" \
+            --repo ${{ github.repository }} \
+            --signer-workflow ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-chart-release.yml

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -1,0 +1,54 @@
+---
+on:
+  workflow_call:
+    inputs:
+      chart_name:
+        type: string
+        required: true
+      chart_path:
+        type: string
+        required: false
+        default: chart
+
+permissions: {}
+
+jobs:
+  chart-release:
+    name: Chart Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set Up Helm
+        id: setup_helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Log in to GitHub Container Registry
+        id: login_ghcr
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package Chart
+        id: package_chart
+        shell: bash
+        env:
+          CHART_PATH: ${{ inputs.chart_path }}
+        run: |
+          helm package "${CHART_PATH}" --destination .helm-deploy
+
+      - name: Push Chart
+        id: push_chart
+        shell: bash
+        run: |
+          helm push .helm-deploy/${{ inputs.chart_name }}-${{ github.ref_name }}.tgz oci://ghcr.io/ministryofjustice/analytical-platform-charts

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set Up Crane
         id: setup_crane
-        uses: ministryofjustice/analytical-platform-github-actions/setup-crane@8474c115b94f9e8c0b6ffda88a8ace111ebe7c33 # port-actions
+        uses: ministryofjustice/analytical-platform-github-actions/setup-crane@main
 
       - name: Set Up Helm
         id: setup_helm

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -69,7 +69,7 @@ jobs:
           CHART_NAME: ${{ inputs.chart-name }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          releaseDigest=$(crane digest ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}:${REF_NAME})
+          releaseDigest=$(crane digest "ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}:${REF_NAME}")
           export releaseDigest
 
           echo "release-digest=${releaseDigest}" >>"${GITHUB_ENV}"

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -29,7 +29,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set Up crane
+      - name: Set Up Cosign
+        id: setup_cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+
+      - name: Set Up Crane
         id: setup_crane
         uses: ministryofjustice/analytical-platform-github-actions/setup-crane@8474c115b94f9e8c0b6ffda88a8ace111ebe7c33 # port-actions
 
@@ -74,16 +78,37 @@ jobs:
 
           echo "release-digest=${releaseDigest}" >>"${GITHUB_ENV}"
 
-      - name: Attest
-        id: attest
+      - name: Cosign
+        id: cosign
+        shell: bash
+        env:
+          CHART_NAME: ${{ inputs.chart-name }}
+          DIGEST: ${{ env.release-digest }}
+        run: |
+          cosign sign --yes "ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}@${DIGEST}"
+
+      - name: GitHub Attestation
+        id: github_attestation
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           subject-name: ghcr.io/ministryofjustice/analytical-platform-charts/${{ inputs.chart-name }}
           subject-digest: ${{ env.release-digest }}
           push-to-registry: true
 
-      - name: GitHub Attestation Verify
-        id: gh_attestation_verify
+      - name: Cosign Verification
+        id: cosign_verification
+        shell: bash
+        env:
+          CHART_NAME: ${{ inputs.chart-name }}
+          DIGEST: ${{ env.release-digest }}
+        run: |
+          cosign verify \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp="https://github\.com/ministryofjustice/analytical-platform-github-actions/\.github/workflows/reusable-chart-release\.yml.+" \
+            "ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}@${DIGEST}"
+
+      - name: GitHub Attestation Verification
+        id: github_attestation_verification
         shell: bash
         env:
           CHART_NAME: ${{ inputs.chart-name }}

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -2,10 +2,10 @@
 on:
   workflow_call:
     inputs:
-      chart_name:
+      chart-name:
         type: string
         required: true
-      chart_path:
+      chart-path:
         type: string
         required: false
         default: chart
@@ -43,7 +43,7 @@ jobs:
         id: package_chart
         shell: bash
         env:
-          CHART_PATH: ${{ inputs.chart_path }}
+          CHART_PATH: ${{ inputs.chart-path }}
         run: |
           helm package "${CHART_PATH}" --destination .helm-deploy
 
@@ -51,7 +51,7 @@ jobs:
         id: push_chart
         shell: bash
         env:
-          CHART_NAME: ${{ inputs.chart_name }}
+          CHART_NAME: ${{ inputs.chart-name }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           helm push ".helm-deploy/${CHART_NAME}-${REF_NAME}.tgz" oci://ghcr.io/ministryofjustice/analytical-platform-charts

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set Up crane
+        id: setup_crane
+        uses: ministryofjustice/analytical-platform-github-actions/setup-crane@8474c115b94f9e8c0b6ffda88a8ace111ebe7c33 # port-actions
+
       - name: Set Up Helm
         id: setup_helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
@@ -58,12 +62,24 @@ jobs:
         run: |
           helm push ".helm-deploy/${CHART_NAME}-${REF_NAME}.tgz" oci://ghcr.io/ministryofjustice/analytical-platform-charts
 
+      - name: Get Release Digest
+        id: get_release_digest
+        shell: bash
+        env:
+          CHART_NAME: ${{ inputs.chart-name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          releaseDigest=$(crane digest ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}:${REF_NAME})
+          export releaseDigest
+
+          echo "release-digest=${releaseDigest}" >>"${GITHUB_ENV}"
+
       - name: Attest
         id: attest
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           subject-name: ghcr.io/ministryofjustice/analytical-platform-charts/${{ inputs.chart-name }}
-          subject-digest: ${{ steps.push_chart.outputs.digest }}
+          subject-digest: ${{ env.release-digest }}
           push-to-registry: true
 
       - name: GitHub Attestation Verify
@@ -75,6 +91,6 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           gh attestation verify \
-            "oci://ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}" \
+            "oci://ghcr.io/ministryofjustice/analytical-platform-charts/${CHART_NAME}:${REF_NAME}" \
             --repo ${{ github.repository }} \
             --signer-workflow ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-chart-release.yml

--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Push Chart
         id: push_chart
         shell: bash
+        env:
+          CHART_NAME: ${{ inputs.chart_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          helm push .helm-deploy/${{ inputs.chart_name }}-${{ github.ref_name }}.tgz oci://ghcr.io/ministryofjustice/analytical-platform-charts
+          helm push ".helm-deploy/${CHART_NAME}-${REF_NAME}.tgz" oci://ghcr.io/ministryofjustice/analytical-platform-charts

--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           confirm: true
 
-      - name: Install cosign
-        id: install_cosign
+      - name: Set Up Cosign
+        id: setup_cosign
         uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
 
       - name: Log in to GitHub Container Registry
@@ -46,8 +46,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 
-      - name: Sign
-        id: sign
+      - name: Cosign
+        id: cosign
         shell: bash
         env:
           DIGEST: ${{ steps.build_and_push.outputs.digest }}
@@ -62,15 +62,15 @@ jobs:
           format: cyclonedx-json
           output-file: "sbom.cyclonedx.json"
 
-      - name: Attest
-        id: attest
+      - name: Github Attestation
+        id: github_attestation
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build_and_push.outputs.digest }}
           push-to-registry: true
 
-      - name: Attest SBOM
+      - name: GitHub Attestation SBOM
         id: attest_sbom
         uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
         with:
@@ -79,8 +79,8 @@ jobs:
           sbom-path: sbom.cyclonedx.json
           push-to-registry: true
 
-      - name: cosign Verify
-        id: cosign_verify
+      - name: Cosign Verification
+        id: cosign_verification
         shell: bash
         env:
           DIGEST: ${{ steps.build_and_push.outputs.digest }}
@@ -90,8 +90,8 @@ jobs:
             --certificate-identity-regexp="https://github\.com/ministryofjustice/analytical-platform-github-actions/\.github/workflows/reusable-container-release\.yml.+" \
             "ghcr.io/${{ github.repository }}@${DIGEST}"
 
-      - name: GitHub Attestation Verify
-        id: gh_attestation_verify
+      - name: GitHub Attestation Verification
+        id: github_attestation_verification
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:
           confirm: true
 

--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:
           confirm: true
 

--- a/.github/workflows/reusable-container-test.yml
+++ b/.github/workflows/reusable-container-test.yml
@@ -19,13 +19,13 @@ jobs:
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:
           confirm: true
 
       - name: Set Up Container Structure Test
         id: setup_container_structure_test
-        uses: ministryofjustice/github-actions/setup-container-structure-test@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/setup-container-structure-test@main
 
       - name: Build
         id: build

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:
           confirm: true
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set Up uv
+      - name: Set Up UV
         id: setup_uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This repository is a store for Analytical Platform's composite actions and reusa
 
 ## Reusable Workflows
 
+## Chart Lint
+
+Lints a Helm chart with [helm/chart-testing](https://github.com/helm/chart-testing)
+
+## Chart Release
+
+Pushes a chart to GHCR
+
 ### Container Release
 
 Builds and pushes a container GHCR, including attestations


### PR DESCRIPTION
## Proposed Changes

- Adds `.github/workflows/reusable-chart-lint.yml` to lint a Helm chart with `ct`
- Adds `.github/workflows/reusable-chart-release.yml` to push a chart to GHCR on tag

## TODO

- [x] https://github.com/ministryofjustice/analytical-platform-github-actions/pull/11
- [x] Update references to composite actions

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>