### PR TITLE
🛂 Add `scan-severity` input to container scanning

### DIFF
--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -1,6 +1,11 @@
 ---
 on:
   workflow_call:
+    inputs:
+      scan-severity:
+        type: string
+        required: false
+        default: HIGH,CRITICAL
 
 permissions: {}
 
@@ -79,6 +84,6 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: ${{ github.sha }}
-          severity: HIGH,CRITICAL
+          severity: ${{ inputs.scan-severity }}
           ignore-unfixed: true
           exit-code: 1

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -1,6 +1,11 @@
 ---
 on:
   workflow_call:
+    inputs:
+      scan-severity:
+        type: string
+        required: false
+        default: HIGH,CRITICAL
     secrets:
       cve-scan-slack-webhook-url:
         required: true

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -91,7 +91,7 @@ jobs:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ env.latest-release-tag }}
-          severity: HIGH,CRITICAL
+          severity: ${{ inputs.scan-severity }}
           ignore-unfixed: true
           exit-code: 1
 

--- a/docs/usage/workflows/container-scan.md
+++ b/docs/usage/workflows/container-scan.md
@@ -2,6 +2,12 @@
 
 Builds and scans a container for vulnerabilities with [Trivy](https://github.com/aquasecurity/trivy) using [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action)
 
+## Inputs
+
+|      Input      |   Type   | Required |     Default     |
+| :-------------: | :------: | :------: | :-------------: |
+| `scan-severity` | `string` | `false`  | `HIGH,CRITICAL` |
+
 ## Usage
 
 ```yaml

--- a/docs/usage/workflows/scheduled-container-scan.md
+++ b/docs/usage/workflows/scheduled-container-scan.md
@@ -2,6 +2,12 @@
 
 Scans the latest release for vulnerabilities with [Trivy](https://github.com/aquasecurity/trivy) using [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action)
 
+## Inputs
+
+|      Input      |   Type   | Required |     Default     |
+| :-------------: | :------: | :------: | :-------------: |
+| `scan-severity` | `string` | `false`  | `HIGH,CRITICAL` |
+
 ## Usage
 
 ```yaml


### PR DESCRIPTION
## Proposed Changes

- Adds `scan-severity` as an input to scanning workflows

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>