### PR TITLE
🦝 Update Super Linter usage documentation

### DIFF
--- a/docs/usage/workflows/super-linter.md
+++ b/docs/usage/workflows/super-linter.md
@@ -46,6 +46,7 @@ jobs:
     with:
       super-linter-variables: |
         {
-          VALIDATE_X: false
+          "VALIDATE_X": false,
+          "KEY": "value"
         }
 ```


### PR DESCRIPTION
## Proposed Changes

- Updates Super Linter usage documentation to show that `super-linter-variables` must be quoted because its a JSON object

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>