### PR TITLE
❌ Throw an error when failure occurs

### DIFF
--- a/.github/workflows/reusable-commit-signature-checker.yml
+++ b/.github/workflows/reusable-commit-signature-checker.yml
@@ -40,4 +40,7 @@ jobs:
                 issue_number: prNumber,
                 body: message,
               });
+
+              // Fail the workflow
+              throw new Error(`Found ${unverified.length} unverified commit(s).`);
             }


### PR DESCRIPTION
Currrently even when a commit is not signed and the action notices this it doesn't error and therefore the check passes. This seeks to resolve that. 

Tested this [here](https://github.com/Gary-H9/github-issues-playground/pull/37) and it worked.

[Passes](https://github.com/Gary-H9/github-issues-playground/actions/runs/15472191937/job/43559158633) when the new line is commented out. 

[Fails](https://github.com/Gary-H9/github-issues-playground/actions/runs/15472097001/job/43558839918#step:2:31) when it's in.