### PR TITLE
🌈 Allow internal non-pinned references

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,6 @@
+---
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        ministryofjustice/analytical-platform-github-actions/*: ref-pin


### PR DESCRIPTION
## Proposed Changes

- There are several references internally to this repository that do not pin with a SHA ([source](https://github.com/search?q=repo%3Aministryofjustice%2Fanalytical-platform-github-actions+%22%40main%22+path%3A%2F%5E%5C.github%5C%2Fworkflows%5C%2F%2F&type=code)). This pull request allows them to use `ref-pin` instead of `sha-pin`

## Context

We decided early on (ADR TBC) that internal composite actions (`ministryofjustice/analytical-platform-github-actions`) are trusted, and do not need SHA pinning. This is because SHA pinning an internal composite action introduces a potential infinite Dependabot cycle, for example:

1. Merge a change to a composite action
2. Create a release
3. Dependabot runs to and sees a new version
4. Merge Dependabot change
5. ...
6. Start again

## Reference

https://docs.zizmor.sh/audits/#unpinned-uses

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>