### PR TITLE
🌈 Run Zizmor on push to `main`

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 permissions: {}
 


### PR DESCRIPTION
## Proposed Changes

- Runs Zizmor workflow on push to `main` branch, which is good practice!

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>