### PR TITLE
🎏 Adds flag to switch clean actions runner off if required

### DIFF
--- a/.github/workflows/reusable-container-release.yml
+++ b/.github/workflows/reusable-container-release.yml
@@ -1,6 +1,11 @@
 ---
 on:
   workflow_call:
+    inputs:
+      clean-actions-runner:
+        type: boolean
+        required: false
+        default: true
 
 permissions: {}
 
@@ -29,6 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean Actions Runner
+        if: inputs.clean-actions-runner == true
         id: clean_actions_runner
         uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:

--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -2,6 +2,10 @@
 on:
   workflow_call:
     inputs:
+      clean-actions-runner:
+        type: boolean
+        required: false
+        default: true
       scan-severity:
         type: string
         required: false
@@ -30,6 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean Actions Runner
+        if: inputs.clean-actions-runner == true
         id: clean_actions_runner
         uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:

--- a/.github/workflows/reusable-container-test.yml
+++ b/.github/workflows/reusable-container-test.yml
@@ -1,6 +1,11 @@
 ---
 on:
   workflow_call:
+    inputs:
+      clean-actions-runner:
+        type: boolean
+        required: false
+        default: true
 
 permissions: {}
 
@@ -25,6 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean Actions Runner
+        if: inputs.clean-actions-runner == true
         id: clean_actions_runner
         uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -2,6 +2,10 @@
 on:
   workflow_call:
     inputs:
+      clean-actions-runner:
+        type: boolean
+        required: false
+        default: true
       scan-severity:
         type: string
         required: false
@@ -27,6 +31,7 @@ jobs:
           egress-policy: audit
 
       - name: Clean Actions Runner
+        if: inputs.clean-actions-runner == true
         id: clean_actions_runner
         uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@main
         with:

--- a/docs/usage/workflows/container-release.md
+++ b/docs/usage/workflows/container-release.md
@@ -2,6 +2,12 @@
 
 Release a container to GitHub Container Registry, including Cosign and GitHub Attestation
 
+## Inputs
+
+|         Input          |  Type  | Required | Default |
+| :--------------------: | :----: | :------: | :-----: |
+| `clean-actions-runner` | `bool` | `false`  | `true`  |
+
 ## Usage
 
 ```yaml

--- a/docs/usage/workflows/container-scan.md
+++ b/docs/usage/workflows/container-scan.md
@@ -4,9 +4,10 @@ Builds and scans a container for vulnerabilities with [Trivy](https://github.com
 
 ## Inputs
 
-|      Input      |   Type   | Required |     Default     |
-| :-------------: | :------: | :------: | :-------------: |
-| `scan-severity` | `string` | `false`  | `HIGH,CRITICAL` |
+|         Input          |   Type   | Required |     Default     |
+| :--------------------: | :------: | :------: | :-------------: |
+| `clean-actions-runner` |  `bool`  | `false`  |     `true`      |
+|    `scan-severity`     | `string` | `false`  | `HIGH,CRITICAL` |
 
 ## Usage
 

--- a/docs/usage/workflows/container-test.md
+++ b/docs/usage/workflows/container-test.md
@@ -2,6 +2,12 @@
 
 Builds and tests a container with [Container Structure Test](https://github.com/GoogleContainerTools/container-structure-test)
 
+## Inputs
+
+|         Input          |  Type  | Required | Default |
+| :--------------------: | :----: | :------: | :-----: |
+| `clean-actions-runner` | `bool` | `false`  | `true`  |
+
 ## Usage
 
 ```yaml


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Adds `clean-actions-runner` as an input to container workflows. Defaults to `true` so it maintain compatibility, but allows setting to `false`. Useful for small images, like Alpine.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>