### PR TITLE
Create commit action and amend workflow usage

### DIFF
--- a/.github/actions/commit-file/action.yml
+++ b/.github/actions/commit-file/action.yml
@@ -1,0 +1,67 @@
+name: Commit File
+description: Commit a file to a branch using the GitHub Contents API
+
+inputs:
+  token:
+    description: GitHub token used for authentication
+    required: true
+  message:
+    description: Commit message
+    required: true
+  path:
+    description: Path to the file to commit
+    required: true
+  branch:
+    description: Branch name to commit to (defaults to current ref)
+    required: false
+    default: ""
+  repository:
+    description: Repository in owner/name format (defaults to current repository)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Commit file with GitHub API
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_MESSAGE: ${{ inputs.message }}
+      run: |
+        set -euo pipefail
+
+        repo="${INPUT_REPOSITORY}"
+        if [ -z "${repo}" ]; then
+          repo="${GITHUB_REPOSITORY}"
+        fi
+
+        branch="${INPUT_BRANCH}"
+        if [ -z "${branch}" ]; then
+          branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+        fi
+
+        path="${INPUT_PATH}"
+        message="${INPUT_MESSAGE}"
+        contents="$(base64 -w 0 "${path}")"
+
+        existing_sha="$(
+          gh api "repos/${repo}/contents/${path}?ref=${branch}" \
+            --jq '.sha' 2>/dev/null || echo ""
+        )"
+
+        if [ -n "${existing_sha}" ]; then
+          gh api --method PUT "repos/${repo}/contents/${path}" \
+            -f message="${message}" \
+            -f content="${contents}" \
+            -f branch="${branch}" \
+            -f sha="${existing_sha}"
+        else
+          gh api --method PUT "repos/${repo}/contents/${path}" \
+            -f message="${message}" \
+            -f content="${contents}" \
+            -f branch="${branch}"
+        fi

--- a/.github/workflows/reusable-pre-commit-update.yml
+++ b/.github/workflows/reusable-pre-commit-update.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Commit changes
         if: env.changed == 'true'
         id: commit_changes
-        uses: ministryofjustice/analytical-platform-github-actions/.github/actions/commit-file@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f35f1 # <version>
+        uses: ministryofjustice/analytical-platform-github-actions/.github/actions/commit-file@4dfd0c023cf551052cefa0ffa6f53b7ecc3a45d5 # <version>
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           message: "🤖 Update .pre-commit-config.yaml"

--- a/.github/workflows/reusable-pre-commit-update.yml
+++ b/.github/workflows/reusable-pre-commit-update.yml
@@ -63,14 +63,13 @@ jobs:
       - name: Commit changes
         if: env.changed == 'true'
         id: commit_changes
-        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        uses: ministryofjustice/analytical-platform-github-actions/.github/actions/commit-file@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f35f1 # <version>
         with:
-          commit_message: "🤖 Update .pre-commit-config.yaml"
-          file_pattern: ".pre-commit-config.yaml"
-          repo: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          message: "🤖 Update .pre-commit-config.yaml"
+          path: ".pre-commit-config.yaml"
           branch: ${{ env.branchName }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
 
       - name: Find previous pull request
         id: find_previous_pr


### PR DESCRIPTION
This pull request introduces a new custom GitHub Action for committing files to a repository using the GitHub Contents API, and updates the workflow to use this action instead of a third-party solution. The main goal is to improve control and maintainability over file commits in CI workflows.

**Introduction of custom commit action:**

* Added a new composite action in `.github/actions/commit-file/action.yml` that commits a file to a branch using the GitHub Contents API, supporting configurable commit message, file path, branch, and repository inputs.

**Workflow updates:**

* Updated `.github/workflows/reusable-pre-commit-update.yml` to use the new `commit-file` action instead of the external `planetscale/ghcommit-action`, ensuring better integration and ownership.
* Adjusted workflow inputs to match the new action’s interface, including `token`, `message`, `path`, `branch`, and `repository`, and removed redundant environment variables.