### PR TITLE
Replace PlanetScale/commit with Contents API

### DIFF
--- a/.github/workflows/reusable-pre-commit-update.yml
+++ b/.github/workflows/reusable-pre-commit-update.yml
@@ -63,14 +63,30 @@ jobs:
       - name: Commit changes
         if: env.changed == 'true'
         id: commit_changes
-        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
-        with:
-          commit_message: "🤖 Update .pre-commit-config.yaml"
-          file_pattern: ".pre-commit-config.yaml"
-          repo: ${{ github.repository }}
-          branch: ${{ env.branchName }}
+        run: |
+          branch="${branchName}"
+          path=".pre-commit-config.yaml"
+          contents="$(base64 -w 0 "${path}")"
+
+          existing_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${branch}" \
+              --jq '.sha' 2>/dev/null || echo ""
+          )"
+
+          if [ -n "${existing_sha}" ]; then
+            gh api --method PUT "repos/${GITHUB_REPOSITORY}/contents/${path}" \
+              -f message="🤖 Update .pre-commit-config.yaml" \
+              -f content="${contents}" \
+              -f branch="${branch}" \
+              -f sha="${existing_sha}"
+          else
+            gh api --method PUT "repos/${GITHUB_REPOSITORY}/contents/${path}" \
+              -f message="🤖 Update .pre-commit-config.yaml" \
+              -f content="${contents}" \
+              -f branch="${branch}"
+          fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find previous pull request
         id: find_previous_pr


### PR DESCRIPTION
This pull request updates the way changes to `.pre-commit-config.yaml` are committed in the `reusable-pre-commit-update.yml` workflow. Instead of using the `planetscale/ghcommit-action`, it now uses a custom shell script with the GitHub CLI to commit updates. This provides more control over the commit process and better handles the presence or absence of the file.

**Workflow automation improvements:**

* Replaced the `planetscale/ghcommit-action` with a custom shell script that uses the `gh` CLI to commit changes to `.pre-commit-config.yaml`, handling both file updates and creation depending on whether the file already exists.
* Updated the environment variable from `GITHUB_TOKEN` to `GH_TOKEN` to align with the GitHub CLI requirements.

This work is tracked in this [ticket ](https://github.com/ministryofjustice/analytical-platform-security/issues/25)