### PR TITLE
Add is-monorepo conditional to chart release workflow

### DIFF
--- a/.github/workflows/reusable-chart-release.yml
+++ b/.github/workflows/reusable-chart-release.yml
@@ -44,6 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify Monorepo Tag Format
+        if: ${{ inputs.is-monorepo }}
         env:
           REF_NAME: ${{ github.ref_name }}
           CHART_NAME: ${{ inputs.chart-name }}

--- a/docs/usage/workflows/chart-release.md
+++ b/docs/usage/workflows/chart-release.md
@@ -4,10 +4,11 @@ Releases a Helm Chart to GitHub Container Registry, including Cosign and GitHub 
 
 ## Inputs
 
-|    Input     |   Type   | Required | Default |
-| :----------: | :------: | :------: | :-----: |
-| `chart-name` | `string` |  `true`  |         |
-| `chart-path` | `string` | `false`  | `chart` |
+|     Input     |   Type    | Required | Default |
+| :-----------: | :-------: | :------: | :-----: |
+| `chart-name`  | `string`  |  `true`  |         |
+| `chart-path`  | `string`  | `false`  | `chart` |
+| `is-monorepo` | `boolean` | `false`  | `false` |
 
 ## Usage
 


### PR DESCRIPTION
To avoid verifying all repos as monorepos. Initially caught this bug when trying to release Dashboard Service https://github.com/ministryofjustice/analytical-platform-dashboard-service/actions/runs/26504485138/job/78053178327