### PR TITLE
amended how vulns are categorised

### DIFF
--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -196,7 +196,10 @@ jobs:
                         elif ($id | startswith("GHSA-")) then "https://github.com/advisories/\($id)"
                         else "" end) as $url
                       | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.)" else "" end) as $fix
-                      | (.message.text | sub("^A [A-Za-z]+ vulnerability"; "A \($severity) vulnerability")) as $text
+                      | (if (.message.text | test("^A [A-Za-z]+ vulnerability"))
+                         then (.message.text | sub("^A [A-Za-z]+ vulnerability"; "A \($severity) vulnerability"))
+                         else "A \($severity) vulnerability: \(.message.text)"
+                         end) as $text
                       | if $url != "" then "- [\($id)](\($url)) - \($text)\($fix)"
                         else "- \(.ruleId) - \($text)\($fix)"
                         end;

--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -130,12 +130,6 @@ jobs:
 
           SARIF=$(cat result.sarif)
 
-          # Grype records two severities per finding: the SARIF "security-severity" property
-          # (the NVD CVSS base score) and a qualitative severity embedded in the result's
-          # message text. For OS/distro packages the qualitative severity reflects the distro
-          # (e.g. Ubuntu) rating, so we categorise on it to keep the bucket consistent with the
-          # severity shown to the user. It is parsed from the leading "A <severity> vulnerability".
-
           CRITICAL_COUNT=$(echo "${SARIF}" | jq '
             def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
             [.runs[0].results[] | select(sev == "critical")] | length
@@ -145,9 +139,6 @@ jobs:
             [.runs[0].results[] | select(sev == "high")] | length
           ')
           TOTAL=$((CRITICAL_COUNT + HIGH_COUNT))
-
-          # Finally, it constructs a markdown report. If there are any findings, it includes a detailed section with links to advisories
-          # (if the ruleId contains a CVE or GHSA identifier) and fix version information extracted from the rule's help text.
 
           SCAN_OUTPUT=$({
             echo "# Container Scan Summary"

--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Harden Runner
         if: github.event.repository.private == false
         id: harden_runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout
         id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload SARIF
         id: upload_sarif
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: result.sarif
 
@@ -130,15 +130,26 @@ jobs:
 
           SARIF=$(cat result.sarif)
 
-          CRITICAL_COUNT=$(echo "${SARIF}" | jq '
-            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
-            [.runs[0].results[] | select(sev == "critical")] | length
+          # The SARIF format stores rules (vulnerability definitions) separately from results (findings).
+          # Build a RULE_SEVERITIES map of ruleId → NVD CVSS base score, then count findings by score band.
+          # The finding message text is rewritten to match the classified severity so the output is consistent.
+
+          RULE_SEVERITIES=$(echo "${SARIF}" | jq -c '
+            .runs[0].tool.driver.rules
+            | map({key: .id, value: (.properties["security-severity"] // "0" | tonumber)})
+            | from_entries
           ')
-          HIGH_COUNT=$(echo "${SARIF}" | jq '
-            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
-            [.runs[0].results[] | select(sev == "high")] | length
+
+          CRITICAL_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
+            [.runs[0].results[] | select($s[.ruleId] >= 9.0)] | length
+          ')
+          HIGH_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
+            [.runs[0].results[] | select($s[.ruleId] >= 7.0 and $s[.ruleId] < 9.0)] | length
           ')
           TOTAL=$((CRITICAL_COUNT + HIGH_COUNT))
+
+          # Finally, it constructs a markdown report. If there are any findings, it includes a detailed section with links to advisories
+          # (if the ruleId contains a CVE or GHSA identifier) and fix version information extracted from the rule's help text.
 
           SCAN_OUTPUT=$({
             echo "# Container Scan Summary"
@@ -152,11 +163,15 @@ jobs:
               echo "## Detailed Findings"
               echo ""
 
-              # get_findings severity — filters SARIF results by qualitative severity and formats each as a markdown bullet.
+              # get_findings min max severity — filters SARIF results by CVSS score band, rewrites the severity word
+              # in each finding's message to match the classified severity, and formats each as a markdown bullet.
               get_findings() {
-                local severity=$1
-                echo "${SARIF}" | jq -r --arg severity "${severity}" '
-                  def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
+                local min_score=$1
+                local max_score=$2
+                local severity=$3
+                echo "${SARIF}" | jq -r --argjson s "${RULE_SEVERITIES}" \
+                  --argjson min "${min_score}" --argjson max "${max_score}" \
+                  --arg severity "${severity}" '
 
                   # 1. Build $fix_versions map: scans each rule'\''s help.text for a "Fix Version:" line and maps ruleId → first fix version
 
@@ -180,21 +195,22 @@ jobs:
                       | (if ($id | startswith("CVE-")) then "https://nvd.nist.gov/vuln/detail/\($id)"
                         elif ($id | startswith("GHSA-")) then "https://github.com/advisories/\($id)"
                         else "" end) as $url
-                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.))" else "" end) as $fix
-                      | if $url != "" then "- [\($id)](\($url)) - \(.message.text)\($fix)"
-                        else "- \(.ruleId) - \(.message.text)\($fix)"
+                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.)" else "" end) as $fix
+                      | (.message.text | sub("^A [A-Za-z]+ vulnerability"; "A \($severity) vulnerability")) as $text
+                      | if $url != "" then "- [\($id)](\($url)) - \($text)\($fix)"
+                        else "- \(.ruleId) - \($text)\($fix)"
                         end;
 
-                  # 3. Filter + emit: stream results[], keep entries matching the qualitative severity, apply advisory_line to each
+                  # 3. Filter + emit: stream results[], keep entries where CVSS score is >= min and < max, apply advisory_line to each
 
                   .runs[0].results[]
-                  | select(sev == $severity)
+                  | select($s[.ruleId] >= $min and $s[.ruleId] < $max)
                   | advisory_line
                 '
               }
 
-              CRITICAL_FINDINGS=$(get_findings "critical")
-              HIGH_FINDINGS=$(get_findings "high")
+              CRITICAL_FINDINGS=$(get_findings 9.0 10.1 "critical")
+              HIGH_FINDINGS=$(get_findings 7.0 9.0 "high")
 
               print_findings "Critical" "${CRITICAL_FINDINGS}"
               print_findings "High" "${HIGH_FINDINGS}"

--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -130,22 +130,19 @@ jobs:
 
           SARIF=$(cat result.sarif)
 
-          # The SARIF format stores rules (vulnerability definitions) separately from results (findings).
-          # The step first builds a RULE_SEVERITIES map of ruleId → score from the rules section.
+          # Grype records two severities per finding: the SARIF "security-severity" property
+          # (the NVD CVSS base score) and a qualitative severity embedded in the result's
+          # message text. For OS/distro packages the qualitative severity reflects the distro
+          # (e.g. Ubuntu) rating, so we categorise on it to keep the bucket consistent with the
+          # severity shown to the user. It is parsed from the leading "A <severity> vulnerability".
 
-          RULE_SEVERITIES=$(echo "${SARIF}" | jq -c '
-            .runs[0].tool.driver.rules
-            | map({key: .id, value: (.properties["security-severity"] // "0" | tonumber)})
-            | from_entries
+          CRITICAL_COUNT=$(echo "${SARIF}" | jq '
+            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
+            [.runs[0].results[] | select(sev == "critical")] | length
           ')
-
-          # Then it counts critical and high severity findings by looking up the score for each result's ruleId in the RULE_SEVERITIES map.
-
-          CRITICAL_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
-            [.runs[0].results[] | select($s[.ruleId] >= 9.0)] | length
-          ')
-          HIGH_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
-            [.runs[0].results[] | select($s[.ruleId] >= 7.0 and $s[.ruleId] < 9.0)] | length
+          HIGH_COUNT=$(echo "${SARIF}" | jq '
+            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
+            [.runs[0].results[] | select(sev == "high")] | length
           ')
           TOTAL=$((CRITICAL_COUNT + HIGH_COUNT))
 
@@ -164,12 +161,11 @@ jobs:
               echo "## Detailed Findings"
               echo ""
 
-              # get_findings min max — filters SARIF results by severity band and formats each as a markdown bullet.
+              # get_findings severity — filters SARIF results by qualitative severity and formats each as a markdown bullet.
               get_findings() {
-                local min_score=$1
-                local max_score=$2
-                echo "${SARIF}" | jq -r --argjson s "${RULE_SEVERITIES}" \
-                  --argjson min "${min_score}" --argjson max "${max_score}" '
+                local severity=$1
+                echo "${SARIF}" | jq -r --arg severity "${severity}" '
+                  def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
 
                   # 1. Build $fix_versions map: scans each rule'\''s help.text for a "Fix Version:" line and maps ruleId → first fix version
 
@@ -193,21 +189,21 @@ jobs:
                       | (if ($id | startswith("CVE-")) then "https://nvd.nist.gov/vuln/detail/\($id)"
                         elif ($id | startswith("GHSA-")) then "https://github.com/advisories/\($id)"
                         else "" end) as $url
-                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.)" else "" end) as $fix
+                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.))" else "" end) as $fix
                       | if $url != "" then "- [\($id)](\($url)) - \(.message.text)\($fix)"
                         else "- \(.ruleId) - \(.message.text)\($fix)"
                         end;
 
-                  # 3. Filter + emit: stream results[], keep entries where severity score is >= min and < max, apply advisory_line to each
+                  # 3. Filter + emit: stream results[], keep entries matching the qualitative severity, apply advisory_line to each
 
                   .runs[0].results[]
-                  | select($s[.ruleId] >= $min and $s[.ruleId] < $max)
+                  | select(sev == $severity)
                   | advisory_line
                 '
               }
 
-              CRITICAL_FINDINGS=$(get_findings 9.0 10.1)
-              HIGH_FINDINGS=$(get_findings 7.0 9.0)
+              CRITICAL_FINDINGS=$(get_findings "critical")
+              HIGH_FINDINGS=$(get_findings "high")
 
               print_findings "Critical" "${CRITICAL_FINDINGS}"
               print_findings "High" "${HIGH_FINDINGS}"

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build Container Image
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: false
@@ -131,18 +131,19 @@ jobs:
 
           SARIF=$(cat result.sarif)
 
-          # Build a lookup map of ruleId -> security-severity score from the rules section
-          RULE_SEVERITIES=$(echo "${SARIF}" | jq -c '
-            .runs[0].tool.driver.rules
-            | map({key: .id, value: (.properties["security-severity"] // "0" | tonumber)})
-            | from_entries
-          ')
+          # Grype records two severities per finding: the SARIF "security-severity" property
+          # (the NVD CVSS base score) and a qualitative severity embedded in the result's
+          # message text. For OS/distro packages the qualitative severity reflects the distro
+          # (e.g. Ubuntu) rating, so we categorise on it to keep the bucket consistent with the
+          # severity shown to the user. It is parsed from the leading "A <severity> vulnerability".
 
-          CRITICAL_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
-            [.runs[0].results[] | select($s[.ruleId] >= 9.0)] | length
+          CRITICAL_COUNT=$(echo "${SARIF}" | jq '
+            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
+            [.runs[0].results[] | select(sev == "critical")] | length
           ')
-          HIGH_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
-            [.runs[0].results[] | select($s[.ruleId] >= 7.0 and $s[.ruleId] < 9.0)] | length
+          HIGH_COUNT=$(echo "${SARIF}" | jq '
+            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
+            [.runs[0].results[] | select(sev == "high")] | length
           ')
           TOTAL=$((CRITICAL_COUNT + HIGH_COUNT))
 
@@ -159,10 +160,9 @@ jobs:
               echo ""
 
               get_findings() {
-                local min_score=$1
-                local max_score=$2
-                echo "${SARIF}" | jq -r --argjson s "${RULE_SEVERITIES}" \
-                  --argjson min "${min_score}" --argjson max "${max_score}" '
+                local severity=$1
+                echo "${SARIF}" | jq -r --arg severity "${severity}" '
+                  def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
                   (.runs[0].tool.driver.rules
                     | map({
                         key: .id,
@@ -179,18 +179,18 @@ jobs:
                       | (if ($id | startswith("CVE-")) then "https://nvd.nist.gov/vuln/detail/\($id)"
                         elif ($id | startswith("GHSA-")) then "https://github.com/advisories/\($id)"
                         else "" end) as $url
-                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.)" else "" end) as $fix
+                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.))" else "" end) as $fix
                       | if $url != "" then "- [\($id)](\($url)) - \(.message.text)\($fix)"
                         else "- \(.ruleId) - \(.message.text)\($fix)"
                         end;
                   .runs[0].results[]
-                  | select($s[.ruleId] >= $min and $s[.ruleId] < $max)
+                  | select(sev == $severity)
                   | advisory_line
                 '
               }
 
-              CRITICAL_FINDINGS=$(get_findings 9.0 10.1)
-              HIGH_FINDINGS=$(get_findings 7.0 9.0)
+              CRITICAL_FINDINGS=$(get_findings "critical")
+              HIGH_FINDINGS=$(get_findings "high")
 
               print_findings "Critical" "${CRITICAL_FINDINGS}"
               print_findings "High" "${HIGH_FINDINGS}"

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -185,7 +185,10 @@ jobs:
                         elif ($id | startswith("GHSA-")) then "https://github.com/advisories/\($id)"
                         else "" end) as $url
                       | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.)" else "" end) as $fix
-                      | (.message.text | sub("^A [A-Za-z]+ vulnerability"; "A \($severity) vulnerability")) as $text
+                      | (if (.message.text | test("^A [A-Za-z]+ vulnerability"))
+                         then (.message.text | sub("^A [A-Za-z]+ vulnerability"; "A \($severity) vulnerability"))
+                         else "A \($severity) vulnerability: \(.message.text)"
+                         end) as $text
                       | if $url != "" then "- [\($id)](\($url)) - \($text)\($fix)"
                         else "- \(.ruleId) - \($text)\($fix)"
                         end;

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -131,12 +131,6 @@ jobs:
 
           SARIF=$(cat result.sarif)
 
-          # Grype records two severities per finding: the SARIF "security-severity" property
-          # (the NVD CVSS base score) and a qualitative severity embedded in the result's
-          # message text. For OS/distro packages the qualitative severity reflects the distro
-          # (e.g. Ubuntu) rating, so we categorise on it to keep the bucket consistent with the
-          # severity shown to the user. It is parsed from the leading "A <severity> vulnerability".
-
           CRITICAL_COUNT=$(echo "${SARIF}" | jq '
             def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
             [.runs[0].results[] | select(sev == "critical")] | length

--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Harden Runner
         if: github.event.repository.private == false
         id: harden_runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout (use main for .grype.yml)
         id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           ref: main
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build Container Image
         id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: false
@@ -131,13 +131,21 @@ jobs:
 
           SARIF=$(cat result.sarif)
 
-          CRITICAL_COUNT=$(echo "${SARIF}" | jq '
-            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
-            [.runs[0].results[] | select(sev == "critical")] | length
+          # The SARIF format stores rules (vulnerability definitions) separately from results (findings).
+          # Build a RULE_SEVERITIES map of ruleId → NVD CVSS base score, then count findings by score band.
+          # The finding message text is rewritten to match the classified severity so the output is consistent.
+
+          RULE_SEVERITIES=$(echo "${SARIF}" | jq -c '
+            .runs[0].tool.driver.rules
+            | map({key: .id, value: (.properties["security-severity"] // "0" | tonumber)})
+            | from_entries
           ')
-          HIGH_COUNT=$(echo "${SARIF}" | jq '
-            def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
-            [.runs[0].results[] | select(sev == "high")] | length
+
+          CRITICAL_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
+            [.runs[0].results[] | select($s[.ruleId] >= 9.0)] | length
+          ')
+          HIGH_COUNT=$(echo "${SARIF}" | jq --argjson s "${RULE_SEVERITIES}" '
+            [.runs[0].results[] | select($s[.ruleId] >= 7.0 and $s[.ruleId] < 9.0)] | length
           ')
           TOTAL=$((CRITICAL_COUNT + HIGH_COUNT))
 
@@ -154,9 +162,12 @@ jobs:
               echo ""
 
               get_findings() {
-                local severity=$1
-                echo "${SARIF}" | jq -r --arg severity "${severity}" '
-                  def sev: ((.message.text | capture("^A (?<w>[A-Za-z]+) vulnerability") | .w | ascii_downcase) // "unknown");
+                local min_score=$1
+                local max_score=$2
+                local severity=$3
+                echo "${SARIF}" | jq -r --argjson s "${RULE_SEVERITIES}" \
+                  --argjson min "${min_score}" --argjson max "${max_score}" \
+                  --arg severity "${severity}" '
                   (.runs[0].tool.driver.rules
                     | map({
                         key: .id,
@@ -173,18 +184,19 @@ jobs:
                       | (if ($id | startswith("CVE-")) then "https://nvd.nist.gov/vuln/detail/\($id)"
                         elif ($id | startswith("GHSA-")) then "https://github.com/advisories/\($id)"
                         else "" end) as $url
-                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.))" else "" end) as $fix
-                      | if $url != "" then "- [\($id)](\($url)) - \(.message.text)\($fix)"
-                        else "- \(.ruleId) - \(.message.text)\($fix)"
+                      | (($fix_versions[.ruleId] // "") | if . != "" then " (fixed in \(.)" else "" end) as $fix
+                      | (.message.text | sub("^A [A-Za-z]+ vulnerability"; "A \($severity) vulnerability")) as $text
+                      | if $url != "" then "- [\($id)](\($url)) - \($text)\($fix)"
+                        else "- \(.ruleId) - \($text)\($fix)"
                         end;
                   .runs[0].results[]
-                  | select(sev == $severity)
+                  | select($s[.ruleId] >= $min and $s[.ruleId] < $max)
                   | advisory_line
                 '
               }
 
-              CRITICAL_FINDINGS=$(get_findings "critical")
-              HIGH_FINDINGS=$(get_findings "high")
+              CRITICAL_FINDINGS=$(get_findings 9.0 10.1 "critical")
+              HIGH_FINDINGS=$(get_findings 7.0 9.0 "high")
 
               print_findings "Critical" "${CRITICAL_FINDINGS}"
               print_findings "High" "${HIGH_FINDINGS}"


### PR DESCRIPTION
After applying this to a number of repo's I have seen some unexpected behaviour - vulns being categorised as High/Critical findings but the text labelling them as medium.

The SARIF report scores on CVSS but the text comes from Grype's own qualitative severity which is derived from the vendor. 

To prevent this miss-match these changes will align the CVVS score with the categories for Critical/High correctly.

Tested here: https://github.com/ministryofjustice/analytical-platform-scheduler/actions/runs/27754540555