### PR TITLE
fix grype-config git auth

### DIFF
--- a/.github/workflows/reusable-container-scan.yml
+++ b/.github/workflows/reusable-container-scan.yml
@@ -46,6 +46,7 @@ jobs:
         id: generate_grype_config
         env:
           CONTAINER_FILE: ${{ inputs.container-file }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           imageName=$(grep "^FROM" "${CONTAINER_FILE}" | cut -d' ' -f2 | cut -d':' -f1)


### PR DESCRIPTION
The `gh api` call in this step has no GH_TOKEN, so it fails auth. The error gets swallowed by `2>/dev/null || true`, which makes the job fail with a generic "Error downloading .grype.yml" instead of a clear auth error. Adding GH_TOKEN fixes it.

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/483) ticket.