### PR TITLE
GH_TOKEN needed for accessing cross repo

### DIFF
--- a/.github/workflows/reusable-scheduled-container-scan.yml
+++ b/.github/workflows/reusable-scheduled-container-scan.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Generate .grype.yml Configuration
         id: generate_grype_config
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           imageName=$(grep "^FROM" Dockerfile | cut -d' ' -f2 | cut -d':' -f1)
 


### PR DESCRIPTION
A `GH_TOKEN` is required to access the cross-repository reference. This was observed in the Visual Studio Code repo, which references `analytical-platform-cloud-development-environment-base` to fetch the `.grype.yml` file.